### PR TITLE
Add home carousel, background removal preview, feature detail gallery, and plaza masonry page

### DIFF
--- a/objectforge-web/.gitignore
+++ b/objectforge-web/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+.DS_Store
+.vscode
+.idea

--- a/objectforge-web/index.html
+++ b/objectforge-web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ObjectForge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/objectforge-web/package.json
+++ b/objectforge-web/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "objectforge-web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.3.0",
+    "@tanstack/react-query": "^5.0.0",
+    "zustand": "^4.4.0",
+    "i18next": "^23.7.0",
+    "react-i18next": "^14.0.0",
+    "i18next-browser-languagedetector": "^7.0.0",
+    "framer-motion": "^11.0.0",
+    "embla-carousel-react": "^8.0.0",
+    "yet-another-react-lightbox": "^3.0.0",
+    "react-photo-album": "^2.0.0",
+    "react-masonry-css": "^1.0.16",
+    "lucide-react": "^0.344.0",
+    "react-router-dom": "^6.22.0",
+    "@radix-ui/react-tooltip": "^1.0.7"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@types/node": "^20.0.0",
+    "shadcn-ui": "^0.8.0"
+  }
+}

--- a/objectforge-web/postcss.config.cjs
+++ b/objectforge-web/postcss.config.cjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/objectforge-web/src/app.tsx
+++ b/objectforge-web/src/app.tsx
@@ -1,0 +1,17 @@
+import Header from './components/Header'
+import Sidebar from './components/Sidebar'
+import BackTop from './components/BackTop'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './router/routes'
+
+export default function App() {
+  return (
+    <>
+      <Header />
+      <Sidebar />
+      <RouterProvider router={router} />
+      <BackTop />
+    </>
+  )
+}
+

--- a/objectforge-web/src/components/BackTop.tsx
+++ b/objectforge-web/src/components/BackTop.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export default function BackTop() {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const handler = () => setVisible(window.scrollY > 600)
+    window.addEventListener('scroll', handler)
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+  if (!visible) return null
+  return (
+    <button
+      className="fixed bottom-4 right-4 p-2 bg-brand text-fg-white rounded"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    >
+      ↑
+    </button>
+  )
+}

--- a/objectforge-web/src/components/Carousel.tsx
+++ b/objectforge-web/src/components/Carousel.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+
+interface Props {
+  slides: React.ReactNode[]
+}
+
+export default function Carousel({ slides }: Props) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true })
+  const timer = useRef<number>()
+
+  const stop = useCallback(() => {
+    if (timer.current) window.clearInterval(timer.current)
+  }, [])
+
+  const play = useCallback(() => {
+    if (!emblaApi) return
+    stop()
+    timer.current = window.setInterval(() => emblaApi.scrollNext(), 3000)
+  }, [emblaApi, stop])
+
+  useEffect(() => {
+    play()
+    return stop
+  }, [play, stop])
+
+  return (
+    <div
+      className="overflow-hidden"
+      ref={emblaRef}
+      onMouseEnter={stop}
+      onMouseLeave={play}
+    >
+      <div className="flex">
+        {slides.map((s, i) => (
+          <div className="flex-[0_0_100%]" key={i}>
+            {s}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/objectforge-web/src/components/CompareSlider.tsx
+++ b/objectforge-web/src/components/CompareSlider.tsx
@@ -1,0 +1,29 @@
+import { useState, ReactNode } from 'react'
+
+interface Props {
+  left: ReactNode
+  right: ReactNode
+}
+
+export default function CompareSlider({ left, right }: Props) {
+  const [value, setValue] = useState(50)
+  return (
+    <div className="relative overflow-hidden">
+      <div className="relative">
+        <div
+          className="absolute top-0 left-0 h-full overflow-hidden"
+          style={{ width: `${value}%` }}
+        >
+          {left}
+        </div>
+        {right}
+      </div>
+      <input
+        type="range"
+        value={value}
+        onChange={(e) => setValue(Number(e.target.value))}
+        className="w-full absolute bottom-0 accent-brand"
+      />
+    </div>
+  )
+}

--- a/objectforge-web/src/components/FeatureCard.tsx
+++ b/objectforge-web/src/components/FeatureCard.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom'
+import NewBadge from './NewBadge'
+import type { Feature } from '../lib/types'
+
+interface Props {
+  feature: Feature
+}
+
+export default function FeatureCard({ feature }: Props) {
+  return (
+    <Link
+      to={`/features/${feature.slug}`}
+      className="block relative p-4 rounded shadow-card bg-bg-3 hover:bg-bg-4 transition-colors"
+    >
+      <div className="absolute top-2 right-2">
+        <NewBadge show={feature.isNew} />
+      </div>
+      <h3 className="font-semibold mb-1">{feature.title}</h3>
+      <p className="text-sm text-fg-2">{feature.description}</p>
+    </Link>
+  )
+}

--- a/objectforge-web/src/components/Header.tsx
+++ b/objectforge-web/src/components/Header.tsx
@@ -1,0 +1,79 @@
+import { useTranslation } from 'react-i18next'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import useHeaderReveal from '../hooks/useHeaderReveal'
+import NewBadge from './NewBadge'
+import { useUIStore } from '../store/ui'
+
+export default function Header() {
+  const hidden = useHeaderReveal()
+  const toggleSidebar = useUIStore((s) => s.toggleSidebar)
+  const { t, i18n } = useTranslation()
+
+  const changeLang = () => {
+    const next = i18n.language === 'en' ? 'zh' : 'en'
+    i18n.changeLanguage(next)
+  }
+
+  const navItems = [
+    { key: 'home' },
+    { key: 'features', isNew: true },
+    { key: 'plaza', soon: true },
+    { key: 'reviews' },
+    { key: 'pricing' }
+  ] as const
+
+  return (
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 bg-bg-1 shadow-card transition-transform ${
+        hidden ? '-translate-y-full' : 'translate-y-0'
+      }`}
+    >
+      <div className="flex items-center justify-between h-16 px-4">
+        <div className="flex items-center gap-2">
+          <div className="w-6 h-6 bg-fg-1" />
+          <span className="font-bold">ObjectForge</span>
+          <button className="ml-2" onClick={toggleSidebar} aria-label="sidebar toggle">
+            ☰
+          </button>
+        </div>
+        <nav className="flex gap-4">
+          {navItems.map((n) => (
+            <Tooltip.Root key={n.key} delayDuration={200}>
+              <Tooltip.Trigger asChild>
+                <a
+                  href="#"
+                  className={`relative flex items-center ${
+                    n.soon ? 'text-gray-400 pointer-events-none' : ''
+                  }`}
+                >
+                  {t(`nav.${n.key}`)}
+                  <span className="absolute -top-2 -right-3">
+                    <NewBadge show={Boolean(n.isNew)} />
+                  </span>
+                </a>
+              </Tooltip.Trigger>
+              {n.soon && (
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    side="bottom"
+                    className="bg-fg-1 text-fg-white text-xs px-2 py-1 rounded"
+                  >
+                    Coming Soon
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              )}
+            </Tooltip.Root>
+          ))}
+        </nav>
+        <div className="flex items-center gap-4">
+          <button onClick={changeLang}>{i18n.language === 'en' ? 'EN' : '中文'}</button>
+          <button>{t('buttons.login')}</button>
+          <button>{t('buttons.register')}</button>
+          <div style={{ display: 'none' }} />
+          <div style={{ display: 'none' }} />
+        </div>
+      </div>
+    </header>
+  )
+}
+

--- a/objectforge-web/src/components/ImageCard.css
+++ b/objectforge-web/src/components/ImageCard.css
@@ -1,0 +1,24 @@
+.image-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+  transition: transform 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .image-card img {
+    transition: none;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .image-card:hover img {
+    transform: scale(1.15);
+  }
+}
+
+@media (hover: none) {
+  .image-card img {
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  }
+}

--- a/objectforge-web/src/components/NewBadge.tsx
+++ b/objectforge-web/src/components/NewBadge.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  show?: boolean
+  until?: string | Date
+}
+
+export default function NewBadge({ show = false, until }: Props) {
+  const active = show && (!until || new Date(until) > new Date())
+  return (
+    <span className="inline-block w-6 h-3.5">
+      {active && (
+        <span className="block w-full h-full text-[10px] leading-[14px] text-center rounded bg-new text-fg-white">
+          NEW
+        </span>
+      )}
+    </span>
+  )
+}
+

--- a/objectforge-web/src/components/Sidebar.tsx
+++ b/objectforge-web/src/components/Sidebar.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { Flame, ThumbsUp, List } from 'lucide-react'
+import { useUIStore } from '../store/ui'
+import { useTranslation } from 'react-i18next'
+
+export default function Sidebar() {
+  const { sidebarOpen } = useUIStore()
+  const { t } = useTranslation()
+  const [filter, setFilter] = useState<'hot' | 'recommend' | 'all'>('hot')
+
+  if (!sidebarOpen) return null
+
+  const icons = { hot: Flame, recommend: ThumbsUp, all: List }
+
+  return (
+    <aside className="fixed top-20 left-4 z-40 flex flex-col gap-4">
+      <div className="flex gap-2">
+        {(['hot', 'recommend', 'all'] as const).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-2 py-1 rounded text-sm ${
+              filter === f ? 'bg-brand text-fg-white' : 'bg-bg-5'
+            }`}
+          >
+            {t(`sidebar.${f}`)}
+          </button>
+        ))}
+      </div>
+      <div className="grid gap-3">
+        {[1, 2, 3, 4, 5, 6].map((n) => {
+          const Icon = icons[filter]
+          return (
+            <Tooltip.Root key={n} delayDuration={200}>
+              <Tooltip.Trigger asChild>
+                <button className="w-14 h-14 rounded-full bg-bg-white shadow-card flex items-center justify-center">
+                  <Icon />
+                </button>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content side="right" className="bg-fg-1 text-fg-white text-xs px-2 py-1 rounded">
+                  {t(`sidebar.${filter}`)} {n}
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}
+

--- a/objectforge-web/src/hooks/useHeaderReveal.ts
+++ b/objectforge-web/src/hooks/useHeaderReveal.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import useScrollDir from './useScrollDir'
+import useIdle from './useIdle'
+
+export default function useHeaderReveal() {
+  const [hidden, setHidden] = useState(false)
+  const dir = useScrollDir()
+  const idle = useIdle(3000)
+  const [inputFocus, setInputFocus] = useState(false)
+
+  useEffect(() => {
+    if (inputFocus) return setHidden(false)
+    setHidden(dir === 'down')
+  }, [dir, inputFocus])
+
+  useEffect(() => {
+    if (!inputFocus) setHidden(idle)
+  }, [idle, inputFocus])
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (e.clientY <= 80) setHidden(false)
+    }
+    const onFocusIn = (e: FocusEvent) => {
+      if ((e.target as HTMLElement).tagName === 'INPUT') setInputFocus(true)
+    }
+    const onFocusOut = (e: FocusEvent) => {
+      if ((e.target as HTMLElement).tagName === 'INPUT') setInputFocus(false)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('focusin', onFocusIn)
+    window.addEventListener('focusout', onFocusOut)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('focusin', onFocusIn)
+      window.removeEventListener('focusout', onFocusOut)
+    }
+  }, [])
+
+  return hidden
+}
+

--- a/objectforge-web/src/hooks/useIdle.ts
+++ b/objectforge-web/src/hooks/useIdle.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+export default function useIdle(timeout = 2000) {
+  const [idle, setIdle] = useState(false)
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+    const reset = () => {
+      setIdle(false)
+      clearTimeout(timer)
+      timer = setTimeout(() => setIdle(true), timeout)
+    }
+    reset()
+    window.addEventListener('mousemove', reset)
+    window.addEventListener('keydown', reset)
+    return () => {
+      window.removeEventListener('mousemove', reset)
+      window.removeEventListener('keydown', reset)
+      clearTimeout(timer)
+    }
+  }, [timeout])
+  return idle
+}

--- a/objectforge-web/src/hooks/useScrollDir.ts
+++ b/objectforge-web/src/hooks/useScrollDir.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+type Dir = 'up' | 'down'
+
+export default function useScrollDir() {
+  const [dir, setDir] = useState<Dir>('up')
+  useEffect(() => {
+    let last = window.scrollY
+    const handler = () => {
+      const current = window.scrollY
+      setDir(current > last ? 'down' : 'up')
+      last = current
+    }
+    window.addEventListener('scroll', handler)
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+  return dir
+}

--- a/objectforge-web/src/i18n/en.json
+++ b/objectforge-web/src/i18n/en.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Home",
+    "features": "Features",
+    "plaza": "Plaza",
+    "reviews": "Reviews",
+    "pricing": "Pricing"
+  },
+  "buttons": {
+    "login": "Login",
+    "register": "Register"
+  },
+  "sidebar": {
+    "hot": "Hot",
+    "recommend": "Recommend",
+    "all": "All"
+  }
+}
+

--- a/objectforge-web/src/i18n/index.ts
+++ b/objectforge-web/src/i18n/index.ts
@@ -1,0 +1,36 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import en from './en.json'
+import zh from './zh.json'
+
+const resources = {
+  en: { translation: en },
+  zh: { translation: zh }
+}
+
+const defaultLng = 'en'
+const stored = typeof window !== 'undefined' ? localStorage.getItem('lang') : null
+const browser = typeof navigator !== 'undefined' ? navigator.language.split('-')[0] : defaultLng
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: stored || defaultLng,
+  fallbackLng: defaultLng,
+  interpolation: { escapeValue: false }
+})
+
+if (!stored && browser !== defaultLng) {
+  i18n.changeLanguage(browser)
+  if (typeof window !== 'undefined') {
+    alert(`Detected ${browser}, switched to ${browser}`)
+  }
+}
+
+i18n.on('languageChanged', (lng) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('lang', lng)
+  }
+})
+
+export default i18n
+

--- a/objectforge-web/src/i18n/zh.json
+++ b/objectforge-web/src/i18n/zh.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "首页",
+    "features": "功能",
+    "plaza": "广场",
+    "reviews": "评价",
+    "pricing": "定价"
+  },
+  "buttons": {
+    "login": "登录",
+    "register": "注册"
+  },
+  "sidebar": {
+    "hot": "热门",
+    "recommend": "推荐",
+    "all": "全部"
+  }
+}
+

--- a/objectforge-web/src/index.css
+++ b/objectforge-web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/objectforge-web/src/lib/api.ts
+++ b/objectforge-web/src/lib/api.ts
@@ -1,0 +1,11 @@
+export const api = {
+  get: (url: string, options?: RequestInit) =>
+    fetch(`/api${url}`, options).then((r) => r.json()),
+  removeBg: (file: File) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    return fetch('/api/v1/bg/remove', { method: 'POST', body: fd }).then((r) =>
+      r.blob()
+    )
+  }
+}

--- a/objectforge-web/src/lib/constants.ts
+++ b/objectforge-web/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const SITE_NAME = 'ObjectForge'

--- a/objectforge-web/src/lib/features.mock.ts
+++ b/objectforge-web/src/lib/features.mock.ts
@@ -1,0 +1,23 @@
+import { Feature } from './types'
+
+export const mockFeatures: Feature[] = [
+  {
+    id: 1,
+    title: 'Feature A',
+    description: 'Description A',
+    slug: 'feature-a',
+    isNew: true
+  },
+  {
+    id: 2,
+    title: 'Feature B',
+    description: 'Description B',
+    slug: 'feature-b'
+  },
+  {
+    id: 3,
+    title: 'Feature C',
+    description: 'Description C',
+    slug: 'feature-c'
+  }
+]

--- a/objectforge-web/src/lib/gallery.mock.ts
+++ b/objectforge-web/src/lib/gallery.mock.ts
@@ -1,0 +1,68 @@
+export interface GalleryItem {
+  id: string;
+  thumb: string;
+  full: string;
+  tags: string[];
+  author: string;
+}
+
+export const gallery: GalleryItem[] = [
+  {
+    id: '1',
+    thumb: 'https://picsum.photos/seed/plaza1/300/400',
+    full: 'https://picsum.photos/seed/plaza1/1200/1600',
+    tags: ['gallery', 'hot'],
+    author: 'Alice'
+  },
+  {
+    id: '2',
+    thumb: 'https://picsum.photos/seed/plaza2/300/350',
+    full: 'https://picsum.photos/seed/plaza2/1200/1400',
+    tags: ['idea', 'tech'],
+    author: 'Bob'
+  },
+  {
+    id: '3',
+    thumb: 'https://picsum.photos/seed/plaza3/300/500',
+    full: 'https://picsum.photos/seed/plaza3/1200/2000',
+    tags: ['festival', 'gallery'],
+    author: 'Carol'
+  },
+  {
+    id: '4',
+    thumb: 'https://picsum.photos/seed/plaza4/300/450',
+    full: 'https://picsum.photos/seed/plaza4/1200/1800',
+    tags: ['tech'],
+    author: 'Dave'
+  },
+  {
+    id: '5',
+    thumb: 'https://picsum.photos/seed/plaza5/300/400',
+    full: 'https://picsum.photos/seed/plaza5/1200/1600',
+    tags: ['idea', 'hot'],
+    author: 'Eve'
+  },
+  {
+    id: '6',
+    thumb: 'https://picsum.photos/seed/plaza6/300/360',
+    full: 'https://picsum.photos/seed/plaza6/1200/1440',
+    tags: ['gallery', 'festival'],
+    author: 'Frank'
+  },
+  {
+    id: '7',
+    thumb: 'https://picsum.photos/seed/plaza7/300/420',
+    full: 'https://picsum.photos/seed/plaza7/1200/1680',
+    tags: ['hot'],
+    author: 'Grace'
+  },
+  {
+    id: '8',
+    thumb: 'https://picsum.photos/seed/plaza8/300/380',
+    full: 'https://picsum.photos/seed/plaza8/1200/1520',
+    tags: ['tech', 'idea'],
+    author: 'Heidi'
+  }
+]
+
+export default gallery

--- a/objectforge-web/src/lib/queryClient.ts
+++ b/objectforge-web/src/lib/queryClient.ts
@@ -1,0 +1,4 @@
+import { QueryClient } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
+export default queryClient

--- a/objectforge-web/src/lib/types.ts
+++ b/objectforge-web/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface Feature {
+  id: number
+  title: string
+  description: string
+  slug: string
+  isNew?: boolean
+}

--- a/objectforge-web/src/main.tsx
+++ b/objectforge-web/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+import App from './app'
+import queryClient from './lib/queryClient'
+import './theme.css'
+import './index.css'
+import './i18n'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/objectforge-web/src/pages/FeatureDetail.tsx
+++ b/objectforge-web/src/pages/FeatureDetail.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import PhotoAlbum, { Photo, RenderPhotoProps } from 'react-photo-album'
+import Lightbox from 'yet-another-react-lightbox'
+import 'yet-another-react-lightbox/styles.css'
+import NewBadge from '../components/NewBadge'
+import '../components/ImageCard.css'
+
+const samplePhotos: Photo[] = [
+  { src: 'https://picsum.photos/seed/1/600/400', width: 600, height: 400 },
+  { src: 'https://picsum.photos/seed/2/600/800', width: 600, height: 800 },
+  { src: 'https://picsum.photos/seed/3/800/600', width: 800, height: 600 },
+  { src: 'https://picsum.photos/seed/4/700/700', width: 700, height: 700 },
+  { src: 'https://picsum.photos/seed/5/600/500', width: 600, height: 500 },
+  { src: 'https://picsum.photos/seed/6/500/600', width: 500, height: 600 }
+]
+
+export default function FeatureDetail() {
+  const { slug } = useParams()
+  const [index, setIndex] = useState(-1)
+
+  return (
+    <div className="p-4 md:grid md:grid-cols-2 md:gap-6">
+      <div className="space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-xl font-semibold flex items-center gap-2">
+            {slug}
+            <NewBadge />
+          </h1>
+          <Link
+            to="/dashboard"
+            className="text-brand underline hover:no-underline"
+          >
+            进入操作中心
+          </Link>
+        </header>
+
+        <section className="border p-4 rounded shadow-card">
+          <h2 className="font-medium mb-2">生成区</h2>
+          <form className="space-y-3">
+            <input
+              className="w-full border rounded p-2"
+              placeholder="Prompt"
+            />
+            <input
+              className="w-full border rounded p-2"
+              placeholder="模板"
+            />
+            <input
+              className="w-full border rounded p-2"
+              placeholder="尺寸"
+            />
+            <button
+              type="button"
+              className="px-4 py-2 rounded bg-brand text-fg-white"
+            >
+              生成
+            </button>
+          </form>
+        </section>
+
+        <section className="border p-4 rounded shadow-card h-64 overflow-auto">
+          <h2 className="font-medium mb-2">对话区</h2>
+          <p className="text-sm text-fg-2">对话占位</p>
+        </section>
+      </div>
+
+      <div className="mt-6 md:mt-0">
+        <PhotoAlbum
+          layout="columns"
+          photos={samplePhotos}
+          columns={(containerWidth) =>
+            containerWidth < 600 ? 1 : containerWidth < 900 ? 2 : 3
+          }
+          onClick={({ index }) => setIndex(index)}
+          renderPhoto={(props) => <ImageWrapper {...props} />}
+        />
+        <Lightbox
+          open={index >= 0}
+          index={index}
+          close={() => setIndex(-1)}
+          slides={samplePhotos.map((p) => ({ src: p.src }))}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ImageWrapper({ photo, renderDefaultPhoto, wrapperStyle }: RenderPhotoProps) {
+  return (
+    <div className="image-card" style={wrapperStyle}>
+      {renderDefaultPhoto({
+        photo,
+        imageProps: { loading: 'lazy', className: 'w-full h-auto' }
+      })}
+    </div>
+  )
+}

--- a/objectforge-web/src/pages/Home.tsx
+++ b/objectforge-web/src/pages/Home.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Carousel from '../components/Carousel'
+import FeatureCard from '../components/FeatureCard'
+import CompareSlider from '../components/CompareSlider'
+import { api } from '../lib/api'
+import { mockFeatures } from '../lib/features.mock'
+import type { Feature } from '../lib/types'
+
+export default function Home() {
+  const { data: features = mockFeatures } = useQuery<Feature[]>({
+    queryKey: ['features'],
+    queryFn: () => api.get('/features').catch(() => mockFeatures)
+  })
+
+  const slides = features.map((f) => <FeatureCard key={f.id} feature={f} />)
+
+  const [orig, setOrig] = useState<string | null>(null)
+  const [result, setResult] = useState<string | null>(null)
+
+  const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setOrig(URL.createObjectURL(file))
+    try {
+      const blob = await api.removeBg(file)
+      setResult(URL.createObjectURL(blob))
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  const useSample = () => {
+    const size = 200
+    const canvas = document.createElement('canvas')
+    canvas.width = canvas.height = size
+    const ctx = canvas.getContext('2d')!
+    ctx.fillStyle = '#2B83DA'
+    ctx.fillRect(0, 0, size, size)
+    ctx.fillStyle = '#fff'
+    ctx.beginPath()
+    ctx.arc(size / 2, size / 2, 50, 0, Math.PI * 2)
+    ctx.fill()
+    const sampleOrig = canvas.toDataURL()
+
+    const canvas2 = document.createElement('canvas')
+    canvas2.width = canvas2.height = size
+    const ctx2 = canvas2.getContext('2d')!
+    ctx2.fillStyle = '#2B83DA'
+    ctx2.beginPath()
+    ctx2.arc(size / 2, size / 2, 50, 0, Math.PI * 2)
+    ctx2.fill()
+    const sampleRes = canvas2.toDataURL('image/png')
+
+    setOrig(sampleOrig)
+    setResult(sampleRes)
+  }
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4 p-4">
+      <Carousel slides={slides} />
+      <div>
+        <div className="mb-2 flex gap-2">
+          <input type="file" accept="image/*" onChange={onUpload} />
+          <button
+            onClick={useSample}
+            className="px-3 py-1 rounded bg-accent2 text-fg-white"
+          >
+            Use Sample
+          </button>
+          {result && (
+            <a
+              href={result}
+              download="removed.png"
+              className="px-3 py-1 rounded bg-accent1 text-fg-white"
+            >
+              Download
+            </a>
+          )}
+        </div>
+        {orig && result ? (
+          <CompareSlider
+            left={<img src={orig} alt="original" className="block max-w-full" />}
+            right={<img src={result} alt="result" className="block max-w-full" />}
+          />
+        ) : (
+          <div className="border-2 border-dashed border-accent1 p-8 text-center text-fg-2">
+            Upload an image to remove background
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/objectforge-web/src/pages/NotFound.tsx
+++ b/objectforge-web/src/pages/NotFound.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div className="p-4">Not Found</div>
+}

--- a/objectforge-web/src/pages/Plaza.tsx
+++ b/objectforge-web/src/pages/Plaza.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import Masonry from 'react-masonry-css'
+import Lightbox from 'yet-another-react-lightbox'
+import 'yet-another-react-lightbox/styles.css'
+import Carousel from '../components/Carousel'
+import { gallery } from '../lib/gallery.mock'
+import '../components/ImageCard.css'
+
+const notices = [
+  '活动一：上传作品赢奖品',
+  '节日特别专题上线',
+  '技术分享会报名中'
+]
+
+const tagDefs = [
+  { key: 'all', label: '全部' },
+  { key: 'gallery', label: '图库' },
+  { key: 'idea', label: '灵感' },
+  { key: 'hot', label: '热门' },
+  { key: 'festival', label: '节日' },
+  { key: 'tech', label: '技术' }
+]
+
+export default function Plaza() {
+  const [activeTag, setActiveTag] = useState('all')
+  const [index, setIndex] = useState(-1)
+
+  const filtered =
+    activeTag === 'all'
+      ? gallery
+      : gallery.filter((item) => item.tags.includes(activeTag))
+
+  const slides = filtered.map((g) => ({ src: g.full }))
+
+  const breakpointColumns = { default: 3, 1024: 3, 768: 2, 500: 1 }
+
+  return (
+    <div className="p-4 space-y-4">
+      <Carousel
+        slides={notices.map((n, i) => (
+          <div
+            key={i}
+            className="p-2 text-center bg-accent2 text-fg-white"
+          >
+            {n}
+          </div>
+        ))}
+      />
+
+      <div className="flex gap-2 flex-wrap">
+        {tagDefs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setActiveTag(t.key)}
+            className={`px-3 py-1 rounded border transition-colors ${
+              activeTag === t.key
+                ? 'bg-brand text-fg-white'
+                : 'bg-bg-9 text-fg-1'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <Masonry
+        breakpointCols={breakpointColumns}
+        className="flex -ml-4 w-auto"
+        columnClassName="pl-4 bg-clip-padding"
+      >
+        {filtered.map((item, i) => (
+          <div
+            key={item.id}
+            className="mb-4 image-card cursor-pointer"
+            onClick={() => setIndex(i)}
+          >
+            <img
+              src={item.thumb}
+              alt={item.author}
+              loading="lazy"
+              className="w-full h-auto"
+            />
+          </div>
+        ))}
+      </Masonry>
+
+      <Lightbox
+        open={index >= 0}
+        index={index}
+        close={() => setIndex(-1)}
+        slides={slides}
+      />
+    </div>
+  )
+}

--- a/objectforge-web/src/pages/Pricing.tsx
+++ b/objectforge-web/src/pages/Pricing.tsx
@@ -1,0 +1,3 @@
+export default function Pricing() {
+  return <div className="p-4">Pricing</div>
+}

--- a/objectforge-web/src/pages/Reviews.tsx
+++ b/objectforge-web/src/pages/Reviews.tsx
@@ -1,0 +1,3 @@
+export default function Reviews() {
+  return <div className="p-4">Reviews</div>
+}

--- a/objectforge-web/src/router/routes.tsx
+++ b/objectforge-web/src/router/routes.tsx
@@ -1,0 +1,18 @@
+import { createBrowserRouter, RouteObject } from 'react-router-dom'
+import Home from '../pages/Home'
+import FeatureDetail from '../pages/FeatureDetail'
+import Plaza from '../pages/Plaza'
+import Reviews from '../pages/Reviews'
+import Pricing from '../pages/Pricing'
+import NotFound from '../pages/NotFound'
+
+const routes: RouteObject[] = [
+  { path: '/', element: <Home /> },
+  { path: '/features/:slug', element: <FeatureDetail /> },
+  { path: '/plaza', element: <Plaza /> },
+  { path: '/reviews', element: <Reviews /> },
+  { path: '/pricing', element: <Pricing /> },
+  { path: '*', element: <NotFound /> }
+]
+
+export const router = createBrowserRouter(routes)

--- a/objectforge-web/src/store/ui.ts
+++ b/objectforge-web/src/store/ui.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface UIState {
+  sidebarOpen: boolean
+  toggleSidebar: () => void
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  sidebarOpen: false,
+  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen }))
+}))

--- a/objectforge-web/src/theme.css
+++ b/objectforge-web/src/theme.css
@@ -1,0 +1,8 @@
+:root{
+  --bg-1:#F5F4ED; --bg-2:#FAF0F5; --bg-3:#EBE9DD; --bg-4:#EEEADD; --bg-5:#F0EEE6;
+  --bg-6:#DCD5C0; --bg-7:#BDB198; --bg-white:#FFFFFF; --bg-9:#F5F5F5;
+  --fg-1:#141413; --fg-2:#23272D; --fg-black:#000000; --fg-white:#FFFFFF;
+  --brand:#2B83DA; --accent-1:#754F31; --accent-2:#409EFF;
+  --new:#E53935; /* 右上角 NEW 红 */
+}
+html,body{ background:var(--bg-1); color:var(--fg-1); }

--- a/objectforge-web/tailwind.config.cjs
+++ b/objectforge-web/tailwind.config.cjs
@@ -1,0 +1,17 @@
+import { type Config } from 'tailwindcss'
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg:{1:'var(--bg-1)',2:'var(--bg-2)',3:'var(--bg-3)',4:'var(--bg-4)',5:'var(--bg-5)',6:'var(--bg-6)',7:'var(--bg-7)',9:'var(--bg-9)'},
+        brand:'var(--brand)', accent1:'var(--accent-1)', accent2:'var(--accent-2)',
+        fg:{1:'var(--fg-1)',2:'var(--fg-2)', black:'var(--fg-black)', white:'var(--fg-white)'},
+        new:'var(--new)'
+      },
+      boxShadow:{ card:'0 6px 24px rgba(0,0,0,.08)'}
+    }
+  },
+  plugins: []
+} satisfies Config

--- a/objectforge-web/tsconfig.json
+++ b/objectforge-web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/objectforge-web/tsconfig.node.json
+++ b/objectforge-web/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/objectforge-web/vite.config.ts
+++ b/objectforge-web/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,4 +1,11 @@
 :root{
+--bg:#0b1020;
+--text:#e5e7eb;
+--primary:#4f46e5;
+--line:#1e293b;
+--muted:#9ca3af;
+--card:#0f1730;
+}
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.6 ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,37 @@
 <!doctype html>
-</section>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ObjectForge · AI 图像工坊</title>
+  <link rel="icon" href="/static/favicon.ico">
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body class="no-css">
+<header id="siteHeader" class="of-header header--hidden" role="banner">
+  <div class="of-header__inner">
+    <a href="/" class="brand">ObjectForge</a>
+    <nav class="of-nav" aria-label="主导航">
+      <a href="#design">AI 设计</a>
+      <a href="#templates">模板</a>
+      <a href="#" class="disabled">更多功能</a>
+    </nav>
+    <a href="#" class="of-cta">登录</a>
+  </div>
+</header>
 
+<main>
+<section class="hero" aria-label="介绍">
+  <div class="hero__wrap">
+    <h1>ObjectForge</h1>
+    <p class="hero__sub">AI 图像工坊，快速生成与编辑视觉素材</p>
+    <div class="hero__actions">
+      <a href="#templates" class="btn btn--primary">开始创作</a>
+      <a href="#design" class="btn btn--ghost">了解更多</a>
+    </div>
+  </div>
+  <div id="headerSentinel" class="hero__sentinel"></div>
+</section>
 
 <!-- 次页面：左 AI 设计 / 右 介绍与信任（OpenAI/Remaker 混合信息页） -->
 <section id="design" class="grid-two grid-two--reverse" aria-label="AI 设计与介绍">
@@ -27,7 +58,6 @@
 </div>
 </article>
 </section>
-
 
 <!-- 模板 / 灵感（保留原 tabs，可复用你已有的数据接入） -->
 <section id="templates" class="of-layer of-layer--tabs" aria-label="模板与灵感">
@@ -63,7 +93,7 @@
 </div>
 </div>
 </section>
-
+</main>
 
 <!-- 页尾（沿用你现有风格） -->
 <footer class="of-footer" role="contentinfo" aria-label="页尾">
@@ -75,7 +105,6 @@
 </div>
 </footer>
 
-
 <script>
 // 外部 CSS 成功后，去掉兜底 no-css
 window.addEventListener('load',()=>{document.body.classList.remove('no-css');});
@@ -83,3 +112,4 @@ window.addEventListener('load',()=>{document.body.classList.remove('no-css');});
 <script src="/static/js/main.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Autoplay feature carousel with NEW badges linking to detail pages
- Upload/compare block for background removal with API integration and sample image
- Slug-based feature detail page with generation form, chat placeholder, and lightbox gallery
- Plaza page with notice carousel, tag filters, and masonry photo wall with lightbox

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-tooltip)*
- `npm run build` *(fails: JSX/TS errors due to missing modules after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68b95484aba483339f3ec6842ae3a158